### PR TITLE
Configure backend to serve SPA frontend build

### DIFF
--- a/part7/blogapp/README.md
+++ b/part7/blogapp/README.md
@@ -1,0 +1,65 @@
+# Single Page Application: BlogApp
+
+## Overview
+This project is a single-page application (SPA) for a blogging platform, structured into two main directories: `frontend` and `backend`. The frontend is a React application, while the backend is built with Node.js and Express. This README outlines the steps to build the application and prepare it for deployment.
+
+## Frontend
+
+### Building the Frontend
+
+1. Navigate to the `frontend` directory:
+
+```
+cd frontend
+```
+
+2. Install dependencies:
+
+```
+npm install
+```
+
+3. Build the application:
+
+```
+npm run build
+```
+
+This will create a `build` directory inside `frontend`, containing the compiled static files.
+
+### Moving Frontend Build to Backend
+1. Copy the contents of the `frontend/build` directory to `backend/build`. This can be done with the following command from the root of the project:
+
+```
+cp -r frontend/build/* backend/build/
+```
+
+
+
+## Backend
+
+### Setting Up the Backend
+1. Navigate to the `backend` directory:
+```
+cd backend
+```
+2. Install dependencies:
+```
+npm install
+```
+
+### Running the Application
+1. Start the backend server:
+```
+npm start
+```
+The server will start and serve the frontend static files from the `backend/build` directory.
+
+2. Access the application by navigating to `http://localhost:3003` in the web browser (replace `3003` with other port if different).
+
+## Additional Notes
+- Make sure to configure the MongoDB URI and other environment variables as needed in the backend.
+- For development, ensure proper proxy settings are configured in the frontend for API calls to the backend.
+
+
+

--- a/part7/blogapp/backend/app.js
+++ b/part7/blogapp/backend/app.js
@@ -1,6 +1,7 @@
 const config = require('./utils/config')
 const express = require('express')
 const app = express()
+const path = require('path')
 const cors = require('cors')
 const logger = require('./utils/logger')
 const mongoose = require('mongoose')
@@ -36,6 +37,15 @@ app.use(express.json())
 app.use('/api/blogs', blogsRouter)
 app.use('/api/users', usersRouter)
 app.use('/api/login', loginRouter)
+
+// Serve static files from the React app
+app.use(express.static(path.join(__dirname, 'build')))
+
+// The catchall handler: for any request that doesn't
+// match the above, send back the frontend's index.html file.
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'build', 'index.html'))
+});
 
 app.use(middleware.unknownEndpoint)
 app.use(middleware.errorHandler)


### PR DESCRIPTION
Modified `app.js` to serve static files from the `frontend` `build` directory. This change allows the Express server to deliver the compiled `frontend` assets (HTML, CSS, JavaScript) for the single-page application (SPA). The `frontend` `build` is now placed in a `build` directory at the root of the `backend` project. This setup simplifies deployment by integrating the frontend and backend into a single service, ensuring that the initial page load delivers the SPA, after which client-side routing and rendering manage the application flow. This approach is particularly beneficial for production environments where a unified service for both frontend and backend is desirable.
